### PR TITLE
Add song library and Apple Watch chord teleprompter

### DIFF
--- a/ChordCue Watch App/ContentView.swift
+++ b/ChordCue Watch App/ContentView.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var store = SongStore()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        if let song = store.songs.first {
+            SongPlayerView(song: song)
+        } else {
+            Text("No songs")
         }
-        .padding()
     }
 }
 

--- a/ChordCue Watch App/Models.swift
+++ b/ChordCue Watch App/Models.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct Chord: Identifiable, Codable {
+    let id = UUID()
+    var name: String
+    var diagram: String
+}
+
+struct Song: Identifiable, Codable {
+    let id = UUID()
+    var title: String
+    var chords: [Chord]
+    var tempo: Double // beats per minute
+}
+
+class SongStore: ObservableObject {
+    @Published var chords: [Chord] = [
+        Chord(name: "C", diagram: "C"),
+        Chord(name: "G", diagram: "G"),
+        Chord(name: "Am", diagram: "Am"),
+        Chord(name: "F", diagram: "F")
+    ]
+    @Published var songs: [Song] = []
+
+    init() {
+        addSong(title: "Sample Song", chordNames: ["C", "G", "Am", "F"], tempo: 120)
+    }
+
+    func addSong(title: String, chordNames: [String], tempo: Double) {
+        let songChords = chordNames.map { name in
+            chords.first(where: { $0.name == name }) ?? Chord(name: name, diagram: name)
+        }
+        songs.append(Song(title: title, chords: songChords, tempo: tempo))
+    }
+
+    func addChord(name: String) {
+        chords.append(Chord(name: name, diagram: name))
+    }
+}

--- a/ChordCue Watch App/SongPlayerView.swift
+++ b/ChordCue Watch App/SongPlayerView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct SongPlayerView: View {
+    let song: Song
+    @State private var index = 0
+    @State private var timer: Timer?
+
+    var body: some View {
+        VStack {
+            Text(song.chords[index].diagram)
+                .font(.title)
+            if index + 1 < song.chords.count {
+                Text("Next: \(song.chords[index + 1].name)")
+                    .font(.footnote)
+                    .padding(.top, 4)
+            }
+        }
+        .onAppear(perform: start)
+        .onDisappear { timer?.invalidate() }
+    }
+
+    func start() {
+        let interval = 60.0 / song.tempo
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
+            if index + 1 < song.chords.count {
+                index += 1
+            } else {
+                timer?.invalidate()
+            }
+        }
+    }
+}

--- a/ChordCue/ContentView.swift
+++ b/ChordCue/ContentView.swift
@@ -8,14 +8,41 @@
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var store = SongStore()
+    @State private var title = ""
+    @State private var chordString = ""
+    @State private var tempo = ""
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationView {
+            List {
+                Section("Songs") {
+                    ForEach(store.songs) { song in
+                        VStack(alignment: .leading) {
+                            Text(song.title).font(.headline)
+                            Text(song.chords.map { $0.name }.joined(separator: " ")).font(.caption)
+                        }
+                    }
+                }
+
+                Section("Add Song") {
+                    TextField("Title", text: $title)
+                    TextField("Chords (space-separated)", text: $chordString)
+                    TextField("Tempo BPM", text: $tempo)
+                        .keyboardType(.decimalPad)
+                    Button("Add") {
+                        let names = chordString.split(separator: " ").map(String.init)
+                        if let bpm = Double(tempo) {
+                            store.addSong(title: title, chordNames: names, tempo: bpm)
+                            title = ""
+                            chordString = ""
+                            tempo = ""
+                        }
+                    }
+                }
+            }
+            .navigationTitle("ChordCue")
         }
-        .padding()
     }
 }
 

--- a/ChordCue/Models.swift
+++ b/ChordCue/Models.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct Chord: Identifiable, Codable {
+    let id = UUID()
+    var name: String
+    var diagram: String
+}
+
+struct Song: Identifiable, Codable {
+    let id = UUID()
+    var title: String
+    var chords: [Chord]
+    var tempo: Double // beats per minute
+}
+
+class SongStore: ObservableObject {
+    @Published var chords: [Chord] = [
+        Chord(name: "C", diagram: "C"),
+        Chord(name: "G", diagram: "G"),
+        Chord(name: "Am", diagram: "Am"),
+        Chord(name: "F", diagram: "F")
+    ]
+    @Published var songs: [Song] = []
+
+    init() {
+        addSong(title: "Sample Song", chordNames: ["C", "G", "Am", "F"], tempo: 120)
+    }
+
+    func addSong(title: String, chordNames: [String], tempo: Double) {
+        let songChords = chordNames.map { name in
+            chords.first(where: { $0.name == name }) ?? Chord(name: name, diagram: name)
+        }
+        songs.append(Song(title: title, chords: songChords, tempo: tempo))
+    }
+
+    func addChord(name: String) {
+        chords.append(Chord(name: name, diagram: name))
+    }
+}


### PR DESCRIPTION
## Summary
- implement `Song`, `Chord`, and `SongStore` models with starter chords
- add iPhone interface to list songs and create new ones with tempo
- create watch teleprompter view that steps through chords at the song's tempo

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68976a6c1fa8832fa857b0377c94cabd