### PR TITLE
Reset song player timer before restart

### DIFF
--- a/ChordCue Watch App/SongPlayerView.swift
+++ b/ChordCue Watch App/SongPlayerView.swift
@@ -20,6 +20,9 @@ struct SongPlayerView: View {
     }
 
     func start() {
+        timer?.invalidate()
+        index = 0
+        guard song.tempo > 0 else { return }
         let interval = 60.0 / song.tempo
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
             if index + 1 < song.chords.count {


### PR DESCRIPTION
## Summary
- Reset existing timer and index when starting a song on the watch app
- Guard against invalid tempo values before scheduling the timer

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897771f9ae8832fb4974b4a51b26cb0