### PR TITLE
Add tabbed song and chord management with repeatable sequences

### DIFF
--- a/ChordCue Watch App/Models.swift
+++ b/ChordCue Watch App/Models.swift
@@ -12,6 +12,7 @@ struct Song: Identifiable, Codable {
     var title: String
     var chords: [Chord]
     var tempo: Double // beats per minute
+    var repeatCount: Int
 }
 
 class SongStore: ObservableObject {
@@ -24,14 +25,18 @@ class SongStore: ObservableObject {
     @Published var songs: [Song] = []
 
     init() {
-        addSong(title: "Sample Song", chordNames: ["C", "G", "Am", "F"], tempo: 120)
+        addSong(title: "Sample Song", chordNames: ["C", "G", "Am", "F"], tempo: 120, repeatCount: 1)
     }
 
-    func addSong(title: String, chordNames: [String], tempo: Double) {
+    func addSong(title: String, chordNames: [String], tempo: Double, repeatCount: Int) {
         let songChords = chordNames.map { name in
             chords.first(where: { $0.name == name }) ?? Chord(name: name, diagram: name)
         }
-        songs.append(Song(title: title, chords: songChords, tempo: tempo))
+        addSong(title: title, chords: songChords, tempo: tempo, repeatCount: repeatCount)
+    }
+
+    func addSong(title: String, chords: [Chord], tempo: Double, repeatCount: Int) {
+        songs.append(Song(title: title, chords: chords, tempo: tempo, repeatCount: repeatCount))
     }
 
     func addChord(name: String) {

--- a/ChordCue Watch App/SongPlayerView.swift
+++ b/ChordCue Watch App/SongPlayerView.swift
@@ -4,13 +4,14 @@ struct SongPlayerView: View {
     let song: Song
     @State private var index = 0
     @State private var timer: Timer?
+    private var totalSteps: Int { song.chords.count * song.repeatCount }
 
     var body: some View {
         VStack {
-            Text(song.chords[index].diagram)
+            Text(song.chords[index % song.chords.count].diagram)
                 .font(.title)
-            if index + 1 < song.chords.count {
-                Text("Next: \(song.chords[index + 1].name)")
+            if index + 1 < totalSteps {
+                Text("Next: \(song.chords[(index + 1) % song.chords.count].name)")
                     .font(.footnote)
                     .padding(.top, 4)
             }
@@ -22,10 +23,10 @@ struct SongPlayerView: View {
     func start() {
         timer?.invalidate()
         index = 0
-        guard song.tempo > 0 else { return }
+        guard song.tempo > 0, totalSteps > 0 else { return }
         let interval = 60.0 / song.tempo
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-            if index + 1 < song.chords.count {
+            if index + 1 < totalSteps {
                 index += 1
             } else {
                 timer?.invalidate()

--- a/ChordCue/ContentView.swift
+++ b/ChordCue/ContentView.swift
@@ -9,9 +9,27 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var store = SongStore()
+
+    var body: some View {
+        TabView {
+            SongListView(store: store)
+                .tabItem {
+                    Label("Songs", systemImage: "music.note.list")
+                }
+            ChordListView(store: store)
+                .tabItem {
+                    Label("Chords", systemImage: "list.bullet")
+                }
+        }
+    }
+}
+
+struct SongListView: View {
+    @ObservedObject var store: SongStore
     @State private var title = ""
-    @State private var chordString = ""
     @State private var tempo = ""
+    @State private var repeatCount = ""
+    @State private var sequence: [Chord] = []
 
     var body: some View {
         NavigationView {
@@ -20,28 +38,70 @@ struct ContentView: View {
                     ForEach(store.songs) { song in
                         VStack(alignment: .leading) {
                             Text(song.title).font(.headline)
-                            Text(song.chords.map { $0.name }.joined(separator: " ")).font(.caption)
+                            Text(song.chords.map { $0.name }.joined(separator: " "))
+                                .font(.caption)
                         }
                     }
                 }
-
                 Section("Add Song") {
                     TextField("Title", text: $title)
-                    TextField("Chords (space-separated)", text: $chordString)
+                    ScrollView(.horizontal) {
+                        HStack {
+                            ForEach(store.chords) { chord in
+                                Button(chord.name) {
+                                    sequence.append(chord)
+                                }
+                                .padding(4)
+                                .background(Color.gray.opacity(0.2))
+                                .cornerRadius(4)
+                            }
+                        }
+                    }
+                    if !sequence.isEmpty {
+                        Text("Sequence: " + sequence.map { $0.name }.joined(separator: " "))
+                            .font(.caption)
+                    }
+                    TextField("Repeat Count", text: $repeatCount)
+                        .keyboardType(.numberPad)
                     TextField("Tempo BPM", text: $tempo)
                         .keyboardType(.decimalPad)
                     Button("Add") {
-                        let names = chordString.split(separator: " ").map(String.init)
-                        if let bpm = Double(tempo) {
-                            store.addSong(title: title, chordNames: names, tempo: bpm)
+                        if let bpm = Double(tempo), let reps = Int(repeatCount), !sequence.isEmpty {
+                            store.addSong(title: title, chords: sequence, tempo: bpm, repeatCount: reps)
                             title = ""
-                            chordString = ""
                             tempo = ""
+                            repeatCount = ""
+                            sequence = []
                         }
                     }
                 }
             }
-            .navigationTitle("ChordCue")
+            .navigationTitle("Songs")
+        }
+    }
+}
+
+struct ChordListView: View {
+    @ObservedObject var store: SongStore
+    @State private var newChord = ""
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section("Chords") {
+                    ForEach(store.chords) { chord in
+                        Text(chord.name)
+                    }
+                }
+                Section("Add Chord") {
+                    TextField("Name", text: $newChord)
+                    Button("Add") {
+                        store.addChord(name: newChord)
+                        newChord = ""
+                    }
+                }
+            }
+            .navigationTitle("Chords")
         }
     }
 }

--- a/ChordCue/Models.swift
+++ b/ChordCue/Models.swift
@@ -12,6 +12,7 @@ struct Song: Identifiable, Codable {
     var title: String
     var chords: [Chord]
     var tempo: Double // beats per minute
+    var repeatCount: Int
 }
 
 class SongStore: ObservableObject {
@@ -24,14 +25,18 @@ class SongStore: ObservableObject {
     @Published var songs: [Song] = []
 
     init() {
-        addSong(title: "Sample Song", chordNames: ["C", "G", "Am", "F"], tempo: 120)
+        addSong(title: "Sample Song", chordNames: ["C", "G", "Am", "F"], tempo: 120, repeatCount: 1)
     }
 
-    func addSong(title: String, chordNames: [String], tempo: Double) {
+    func addSong(title: String, chordNames: [String], tempo: Double, repeatCount: Int) {
         let songChords = chordNames.map { name in
             chords.first(where: { $0.name == name }) ?? Chord(name: name, diagram: name)
         }
-        songs.append(Song(title: title, chords: songChords, tempo: tempo))
+        addSong(title: title, chords: songChords, tempo: tempo, repeatCount: repeatCount)
+    }
+
+    func addSong(title: String, chords: [Chord], tempo: Double, repeatCount: Int) {
+        songs.append(Song(title: title, chords: chords, tempo: tempo, repeatCount: repeatCount))
     }
 
     func addChord(name: String) {


### PR DESCRIPTION
## Summary
- Introduce tab bar separating song list and chord catalog
- Allow building songs by tapping chords, specifying repeats and tempo
- Update watch player to loop through chord sequences at song tempo

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6897866270e0832f96fd9332a7a4f425