### PR TITLE
Add editing and deletion for songs and chords

### DIFF
--- a/ChordCue/ContentView.swift
+++ b/ChordCue/ContentView.swift
@@ -44,6 +44,7 @@ struct SongListView: View {
                             }
                         }
                     }
+                    .onDelete(perform: store.deleteSong)
                 }
                 Section("Add Song") {
                     TextField("Title", text: $title)
@@ -92,8 +93,11 @@ struct ChordListView: View {
             List {
                 Section("Chords") {
                     ForEach(store.chords) { chord in
-                        Text(chord.name)
+                        NavigationLink(destination: ChordEditorView(store: store, chord: chord)) {
+                            Text(chord.name)
+                        }
                     }
+                    .onDelete(perform: store.deleteChord)
                 }
                 Section("Add Chord") {
                     TextField("Name", text: $newChord)
@@ -175,6 +179,39 @@ struct SongEditorView: View {
                         store.updateSong(song, title: title, chords: sequence, tempo: bpm, repeatCount: reps)
                         dismiss()
                     }
+                }
+            }
+        }
+    }
+}
+
+struct ChordEditorView: View {
+    @ObservedObject var store: SongStore
+    var chord: Chord
+    @State private var name: String
+    @State private var diagram: String
+    @Environment(\.dismiss) private var dismiss
+
+    init(store: SongStore, chord: Chord) {
+        self.store = store
+        self.chord = chord
+        _name = State(initialValue: chord.name)
+        _diagram = State(initialValue: chord.diagram)
+    }
+
+    var body: some View {
+        Form {
+            Section("Chord") {
+                TextField("Name", text: $name)
+                TextField("Diagram", text: $diagram)
+            }
+        }
+        .navigationTitle("Edit Chord")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Save") {
+                    store.updateChord(chord, name: name, diagram: diagram)
+                    dismiss()
                 }
             }
         }

--- a/ChordCue/Models.swift
+++ b/ChordCue/Models.swift
@@ -47,4 +47,28 @@ class SongStore: ObservableObject {
         guard let index = songs.firstIndex(where: { $0.id == song.id }) else { return }
         songs[index] = Song(id: song.id, title: title, chords: chords, tempo: tempo, repeatCount: repeatCount)
     }
+
+    func updateChord(_ chord: Chord, name: String, diagram: String? = nil) {
+        guard let index = chords.firstIndex(where: { $0.id == chord.id }) else { return }
+        let updated = Chord(id: chord.id, name: name, diagram: diagram ?? chord.diagram)
+        chords[index] = updated
+        // Update chord in all songs
+        songs = songs.map { song in
+            var newSong = song
+            newSong.chords = song.chords.map { $0.id == chord.id ? updated : $0 }
+            return newSong
+        }
+    }
+
+    func deleteSong(at offsets: IndexSet) {
+        songs.remove(atOffsets: offsets)
+    }
+
+    func deleteChord(at offsets: IndexSet) {
+        let ids = offsets.map { chords[$0].id }
+        chords.remove(atOffsets: offsets)
+        for i in songs.indices {
+            songs[i].chords.removeAll { ids.contains($0.id) }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- enable removing songs and chords from lists
- support editing chords via a dedicated editor
- propagate chord changes to existing songs

## Testing
- `swiftc -typecheck Models.swift ContentView.swift ChordCueApp.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68986dd9e484832f9493dd66ceb9dd96