### PR TITLE
Sync songs to watch and enable playback

### DIFF
--- a/ChordCue Watch App/ContentView.swift
+++ b/ChordCue Watch App/ContentView.swift
@@ -11,10 +11,16 @@ struct ContentView: View {
     @StateObject private var store = SongStore()
 
     var body: some View {
-        if let song = store.songs.first {
-            SongPlayerView(song: song)
-        } else {
-            Text("No songs")
+        NavigationStack {
+            List(store.songs) { song in
+                NavigationLink(song.title) {
+                    SongPlayerView(song: song)
+                }
+            }
+            .navigationTitle("Songs")
+            .onAppear {
+                WatchSessionManager.shared.start(store: store)
+            }
         }
     }
 }

--- a/ChordCue Watch App/Models.swift
+++ b/ChordCue Watch App/Models.swift
@@ -16,35 +16,9 @@ struct Song: Identifiable, Codable {
 }
 
 class SongStore: ObservableObject {
-    @Published var chords: [Chord] = [
-        Chord(name: "C", diagram: "C"),
-        Chord(name: "G", diagram: "G"),
-        Chord(name: "Am", diagram: "Am"),
-        Chord(name: "F", diagram: "F")
-    ]
     @Published var songs: [Song] = []
 
-    init() {
-        addSong(title: "Sample Song", chordNames: ["C", "G", "Am", "F"], tempo: 120, repeatCount: 1)
-    }
-
-    func addSong(title: String, chordNames: [String], tempo: Double, repeatCount: Int) {
-        let songChords = chordNames.map { name in
-            chords.first(where: { $0.name == name }) ?? Chord(name: name, diagram: name)
-        }
-        addSong(title: title, chords: songChords, tempo: tempo, repeatCount: repeatCount)
-    }
-
-    func addSong(title: String, chords: [Chord], tempo: Double, repeatCount: Int) {
-        songs.append(Song(title: title, chords: chords, tempo: tempo, repeatCount: repeatCount))
-    }
-
-    func addChord(name: String) {
-        chords.append(Chord(name: name, diagram: name))
-    }
-
-    func updateSong(_ song: Song, title: String, chords: [Chord], tempo: Double, repeatCount: Int) {
-        guard let index = songs.firstIndex(where: { $0.id == song.id }) else { return }
-        songs[index] = Song(id: song.id, title: title, chords: chords, tempo: tempo, repeatCount: repeatCount)
+    func updateSongs(_ newSongs: [Song]) {
+        songs = newSongs
     }
 }

--- a/ChordCue Watch App/WatchSessionManager.swift
+++ b/ChordCue Watch App/WatchSessionManager.swift
@@ -1,0 +1,31 @@
+import Foundation
+import WatchConnectivity
+
+class WatchSessionManager: NSObject, WCSessionDelegate {
+    static let shared = WatchSessionManager()
+    private let session = WCSession.default
+    private weak var store: SongStore?
+
+    override private init() {
+        super.init()
+    }
+
+    func start(store: SongStore) {
+        self.store = store
+        guard WCSession.isSupported() else { return }
+        session.delegate = self
+        session.activate()
+    }
+
+    // MARK: - WCSessionDelegate
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {}
+
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        guard let data = applicationContext["songs"] as? Data,
+              let decoded = try? JSONDecoder().decode([Song].self, from: data) else { return }
+        DispatchQueue.main.async {
+            self.store?.updateSongs(decoded)
+        }
+    }
+}
+

--- a/ChordCue/ChordCueApp.swift
+++ b/ChordCue/ChordCueApp.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 @main
 struct ChordCueApp: App {
+    init() {
+        WatchSessionManager.shared.start()
+    }
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/ChordCue/Models.swift
+++ b/ChordCue/Models.swift
@@ -22,10 +22,15 @@ class SongStore: ObservableObject {
         Chord(name: "Am", diagram: "Am"),
         Chord(name: "F", diagram: "F")
     ]
-    @Published var songs: [Song] = []
+    @Published var songs: [Song] = [] {
+        didSet {
+            WatchSessionManager.shared.sendSongs(songs)
+        }
+    }
 
     init() {
         addSong(title: "Sample Song", chordNames: ["C", "G", "Am", "F"], tempo: 120, repeatCount: 1)
+        WatchSessionManager.shared.sendSongs(songs)
     }
 
     func addSong(title: String, chordNames: [String], tempo: Double, repeatCount: Int) {

--- a/ChordCue/WatchSessionManager.swift
+++ b/ChordCue/WatchSessionManager.swift
@@ -1,0 +1,34 @@
+import Foundation
+import WatchConnectivity
+
+class WatchSessionManager: NSObject, WCSessionDelegate {
+    static let shared = WatchSessionManager()
+    private let session = WCSession.default
+
+    override private init() {
+        super.init()
+    }
+
+    func start() {
+        guard WCSession.isSupported() else { return }
+        session.delegate = self
+        session.activate()
+    }
+
+    func sendSongs(_ songs: [Song]) {
+        guard session.isPaired && session.isWatchAppInstalled else { return }
+        if let data = try? JSONEncoder().encode(songs) {
+            do {
+                try session.updateApplicationContext(["songs": data])
+            } catch {
+                print("Failed to send songs: \(error)")
+            }
+        }
+    }
+
+    // MARK: - WCSessionDelegate
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+    func sessionDidDeactivate(_ session: WCSession) {}
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {}
+}
+


### PR DESCRIPTION
## Summary
- add WatchConnectivity managers for phone and watch targets
- push songs from iPhone SongStore to watch and list them for selection
- start watch session on app launch and update SongStore on receipt

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68987390ea54832f95d09c472002d094